### PR TITLE
DeprecationWarning with django.conf.urls.defaults

### DIFF
--- a/simple_contact/urls.py
+++ b/simple_contact/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from simple_contact.views import ContactView
 
 urlpatterns = patterns('',


### PR DESCRIPTION
With Django >= 1.4, a _DeprecationWarning_: is shown when using _django.conf.urls.defaults_:

> DeprecationWarning: django.conf.urls.defaults is deprecated; use django.conf.urls instead

From Django 1.6 on, _django.conf.urls.defaults_ will no longer exist. This patch changes that import with the new one, which is _django.conf.urls_.

More information:

> django.conf.urls.defaults will be removed. The functions include(), patterns() and url() plus handler404, handler500, are now available through django.conf.urls.

(via https://docs.djangoproject.com/en/dev/internals/deprecation/)
